### PR TITLE
ti-uim.service: use systemd builtin for || true

### DIFF
--- a/systemd/system/ti-uim.service
+++ b/systemd/system/ti-uim.service
@@ -2,5 +2,5 @@
 Description=User Mode Init Manager for TI shared transport
 
 [Service]
-ExecStartPre=/sbin/modprobe -q btwilink || true
+ExecStartPre=-/sbin/modprobe -q btwilink
 ExecStart=/usr/sbin/uim -f /sys/devices/kim


### PR DESCRIPTION
Signed-off-by: Koen Kooi koen.kooi@linaro.org
