### PR TITLE
modprobe.d: disable btwilink at boot

### DIFF
--- a/modprobe.d/ti-uim.conf
+++ b/modprobe.d/ti-uim.conf
@@ -1,0 +1,1 @@
+blacklist btwilink


### PR DESCRIPTION
To make sure that the bluetooth stack doesnt time out we need to blacklist btwlink.ko.

As soon as btwlink is loaded, hci-core opens the btwilink driver which in turn waits for the uim to open the tty port (for about 6 seconds)
UIM is controlled by systemd and can take some time to load.

So to guarantee synchronization we need to blacklist btwlink and allow systemd to load the module.
