### PR TITLE
uim: add init.d start script

### DIFF
--- a/scripts/uim-sysfs
+++ b/scripts/uim-sysfs
@@ -1,0 +1,34 @@
+#! /bin/sh
+
+NODE=`cd /sys; find . | grep kim | grep install`
+if [ $NODE ]
+then
+    echo UIM SYSFS Node Found at /sys/$NODE
+else
+    echo UIM SYSFS Node Not Found
+    exit 0
+fi
+
+uim="/usr/bin/uim"
+uim_args="-f `dirname /sys/$NODE`"
+
+test -x "$uim" || exit 0
+
+case "$1" in
+  start)
+    echo -n "Starting uim-sysfs daemon"
+    start-stop-daemon --start --quiet --pidfile /var/run/uim.pid --make-pidfile --exec $uim -- $uim_args & 
+    echo "."
+    ;;
+  stop)
+    echo -n "Stopping uim-sysfs daemon"
+    start-stop-daemon --stop --quiet --pidfile /var/run/uim.pid
+    echo "."
+    ;;
+  *)
+    echo "Usage: /etc/init.d/uim-sysfs {start|stop}"
+    exit 1
+esac
+
+exit 0
+


### PR DESCRIPTION
Add an init.d script used for starting the uim daemon
when the kernel boots.

Signed-off-by: Eyal Reizer <eyalr@ti.com>